### PR TITLE
Specify order of AutoConfiguration to resolve bean overriding

### DIFF
--- a/spring-distributed-locks-hazelcast/src/main/java/com/budjb/spring/distributed/lock/hazelcast/HazelcastDistributedLockAutoConfiguration.java
+++ b/spring-distributed-locks-hazelcast/src/main/java/com/budjb/spring/distributed/lock/hazelcast/HazelcastDistributedLockAutoConfiguration.java
@@ -17,11 +17,14 @@
 package com.budjb.spring.distributed.lock.hazelcast;
 
 import com.budjb.spring.distributed.lock.DistributedLockProvider;
+import com.budjb.spring.distributed.lock.DistributedLocksAutoConfiguration;
 import com.hazelcast.core.HazelcastInstance;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@AutoConfigureBefore(DistributedLocksAutoConfiguration.class)
 public class HazelcastDistributedLockAutoConfiguration {
     @Bean
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")

--- a/spring-distributed-locks-redis/src/main/java/com/budjb/spring/distributed/lock/redis/RedisDistributedLockAutoConfiguration.java
+++ b/spring-distributed-locks-redis/src/main/java/com/budjb/spring/distributed/lock/redis/RedisDistributedLockAutoConfiguration.java
@@ -17,13 +17,16 @@
 package com.budjb.spring.distributed.lock.redis;
 
 import com.budjb.spring.distributed.lock.DistributedLockProvider;
+import com.budjb.spring.distributed.lock.DistributedLocksAutoConfiguration;
 import org.redisson.api.RedissonClient;
 import org.redisson.spring.starter.RedissonAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@AutoConfigureBefore(DistributedLocksAutoConfiguration.class)
 @AutoConfigureAfter(RedissonAutoConfiguration.class)
 public class RedisDistributedLockAutoConfiguration {
     @Bean


### PR DESCRIPTION
Documentation of @ConditionalOnMissingBean indicates that order
of AutoConfigurations matter, so this enforces that the packaged
implementations of Redis and Hazelcast will AutoConfigure before
the base, properly overriding the DistributedLockProvider under
the default Spring 2.1 behavior